### PR TITLE
[ATMO-649] Add user ssh keys

### DIFF
--- a/ansible/playbooks/100_atmo_user_ssh_keys.yml
+++ b/ansible/playbooks/100_atmo_user_ssh_keys.yml
@@ -1,0 +1,5 @@
+---
+- name: Playbook to add users personal ssh keys
+  hosts: atmosphere
+  roles:
+      - atmo-user-ssh-keys

--- a/ansible/roles/atmo-user-ssh-keys/handlers/main.yml
+++ b/ansible/roles/atmo-user-ssh-keys/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart ssh
+  service: name={{ SSHD }} state=restarted

--- a/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
+++ b/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Add users ssh keys to authorized_keys2
+  authorized_key: user=root key='{{ USERSSHKEYS|join("\n") }}' state=present exclusive=yes path=/root/.ssh/authorized_keys2
+  become: yes
+  when: USERSSHKEYS is defined

--- a/ansible/roles/atmo-user-ssh-keys/vars/CentOS.yml
+++ b/ansible/roles/atmo-user-ssh-keys/vars/CentOS.yml
@@ -1,0 +1,1 @@
+SSHD: sshd

--- a/ansible/roles/atmo-user-ssh-keys/vars/Ubuntu.yml
+++ b/ansible/roles/atmo-user-ssh-keys/vars/Ubuntu.yml
@@ -1,0 +1,1 @@
+SSHD: ssh

--- a/ansible/roles/atmo-user-ssh-keys/vars/default.yml
+++ b/ansible/roles/atmo-user-ssh-keys/vars/default.yml
@@ -1,0 +1,1 @@
+SSHD: ssh


### PR DESCRIPTION
Here is the ansible playbook to deploy user ssh keys.

See JIRA [ticket](https://pods.iplantcollaborative.org/jira/browse/ATMO-649).
Associated atmosphere [PR](https://github.com/iPlantCollaborativeOpenSource/atmosphere/pull/69).
Associated troposphere [PR](https://github.com/iPlantCollaborativeOpenSource/troposphere/pull/215).