### PR TITLE
SSH allow groups

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,7 @@
 # note, separating out the ansible inventory into a separate directory
 # since by default the group and host vars use the base path of
 # the hosts file
-hostfile       = /opt/dev/atmosphere-ansible-jetstream/ansible/hosts
+hostfile       = /opt/dev/atmosphere-ansible/ansible/hosts
 library        = /usr/share/ansible
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
@@ -37,7 +37,7 @@ module_lang    = C
 gathering = smart
 
 # additional paths to search for roles in, colon separated
-roles_path = /opt/dev/atmosphere/service/ansible/roles:/opt/dev/atmosphere-ansible-jetstream/ansible/roles
+roles_path = /opt/dev/atmosphere/service/ansible/roles:/opt/dev/atmosphere-ansible/ansible/roles
 
 # uncomment this to disable SSH key host checking
 host_key_checking = False

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -14,7 +14,7 @@
 # note, separating out the ansible inventory into a separate directory
 # since by default the group and host vars use the base path of
 # the hosts file
-hostfile       = /opt/dev/atmosphere-ansible/ansible/hosts
+hostfile       = /opt/dev/atmosphere-ansible-jetstream/ansible/hosts
 library        = /usr/share/ansible
 remote_tmp     = $HOME/.ansible/tmp
 pattern        = *
@@ -37,7 +37,7 @@ module_lang    = C
 gathering = smart
 
 # additional paths to search for roles in, colon separated
-roles_path = /opt/dev/atmosphere-ansible/ansible/roles
+roles_path = /opt/dev/atmosphere/service/ansible/roles:/opt/dev/atmosphere-ansible-jetstream/ansible/roles
 
 # uncomment this to disable SSH key host checking
 host_key_checking = False

--- a/ansible/playbooks/18_atmo_local_user_account.yml
+++ b/ansible/playbooks/18_atmo_local_user_account.yml
@@ -1,0 +1,5 @@
+---
+- name: Playbook to set up local user accounts
+  hosts: atmosphere
+  roles:
+    - atmo-local-user-account

--- a/ansible/playbooks/22_iplant_ldap.yml
+++ b/ansible/playbooks/22_iplant_ldap.yml
@@ -1,5 +1,0 @@
----
-- name: Install ldap to iplant specifications 
-  hosts: atmosphere
-  roles:
-    - ldap

--- a/ansible/playbooks/49_atmo_irods.yml
+++ b/ansible/playbooks/49_atmo_irods.yml
@@ -1,5 +1,0 @@
----
-- name: Playbook to install irods
-  hosts: atmosphere
-  roles:
-    - atmo-irods

--- a/ansible/playbooks/50_atmo_realvnc.yml
+++ b/ansible/playbooks/50_atmo_realvnc.yml
@@ -3,5 +3,4 @@
   hosts: atmosphere
   roles:
     # Requires ATMOUSERNAME and VNCLICENSE
-    #- atmo-vncserver
     - atmo-realvncserver

--- a/ansible/playbooks/55_atmo_idrop.yml
+++ b/ansible/playbooks/55_atmo_idrop.yml
@@ -1,6 +1,0 @@
----
-- name: Playbook to install idrop
-  hosts: atmosphere
-  roles:
-    # Requires ATMOUSERNAME
-    - atmo-idrop

--- a/ansible/roles/atmo-common/files/motd
+++ b/ansible/roles/atmo-common/files/motd
@@ -5,10 +5,6 @@
 /_/   \_\__|_| |_| |_|\___/|___/ .__/|_| |_|\___|_|  \___|
                                |_|
 
-iPlant Collaborative 
+Jetstream
 
-The user manual is located here: http://goo.gl/2pT72
-
-To backup user data or volumes on a instance: https://goo.gl/hEcS59
-
-For assistance, contact support@iplantcollaborative.org.  
+For assistance, contact help@xsede.org

--- a/ansible/roles/atmo-common/tasks/main.yml
+++ b/ansible/roles/atmo-common/tasks/main.yml
@@ -109,7 +109,6 @@
 ###########
 # General #
 ###########
-
 - name: remove references to rc.local.atmo in rc.local
   lineinfile: dest=/etc/rc.d/rc.local state=absent line="\n# this is for atmosphere\nif [ -x /etc/rc.d/rc.local.atmo ]; then\n\t/etc/rc.d/rc.local.atmo\nfi" 
   when: ansible_distribution == "CentOS"

--- a/ansible/roles/atmo-common/vars/Ubuntu-16.yml
+++ b/ansible/roles/atmo-common/vars/Ubuntu-16.yml
@@ -1,0 +1,27 @@
+---
+
+SSHD: ssh
+
+RC_LOCAL_ATMO: /etc/rc.local.atmo
+
+PACKAGES:
+  - libfam0
+  - python
+  - python-ldap
+  - python-software-properties
+  - python-httplib2
+  - libfuse2
+  - tmux
+  - screen
+  - autoconf
+  - gcc
+  - make
+  - patch
+  - tcsh
+  - zsh
+  - mosh
+  - qemu-guest-agent
+
+# Add modules to be loaded here
+# MODULES_TO_LOAD:
+#   - acpiphp

--- a/ansible/roles/atmo-dhcp/files/hostname-exit-hook.sh
+++ b/ansible/roles/atmo-dhcp/files/hostname-exit-hook.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PREFIX=vm
+PREFIX="js-"
 
 LOG=/var/log/atmo/dhcp_hostname.log
 
@@ -94,10 +94,6 @@ if [[ -z $hostname_value ]]; then
     hostname $fallback_hostname
     echo $(date +"%m%d%y %H:%M:%S") " Hostname could not be determined. using `hostname`" >> $LOG
 else
-    if [[ $hostname_value  == 129.114.5.* ]]; then
-       hostname "austin5-"$(echo $hostname_value | awk 'BEGIN {FS="."};{print $4}')".cloud.bio.ci"
-    else
-       hostname $hostname_value
-    fi
+    hostname $hostname_value
     echo $(date +"%m%d%y %H:%M:%S") "   Hostname has been set to `hostname`" >> $LOG
 fi

--- a/ansible/roles/atmo-fail2ban/tasks/ubuntu-setup.yml
+++ b/ansible/roles/atmo-fail2ban/tasks/ubuntu-setup.yml
@@ -9,7 +9,16 @@
 - name: configure fail2ban local jails
   action: template src=ubuntu-jail.local.j2 dest=/etc/fail2ban/jail.local mode=0644
   notify: restart fail2ban ubuntu
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version < '15'
   tags: configuration
+
+- name: configure fail2ban local jails
+  action: template src={{ item }} dest=/etc/fail2ban/jail.local mode=0644
+  notify: restart fail2ban ubuntu
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == '15'
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.jail.local.j2"
+    - "{{ ansible_distribution }}.jail.local.j2"
 
 - name: restart fail2ban service
   service: name=fail2ban state=restarted enabled=yes

--- a/ansible/roles/atmo-fail2ban/templates/Ubuntu-15.jail.local.j2
+++ b/ansible/roles/atmo-fail2ban/templates/Ubuntu-15.jail.local.j2
@@ -1,0 +1,784 @@
+#
+# WARNING: heavily refactored in 0.9.0 release.  Please review and
+#          customize settings for your setup.
+#
+# Changes:  in most of the cases you should not modify this
+#           file, but provide customizations in jail.local file,
+#           or separate .conf files under jail.d/ directory, e.g.:
+#
+# HOW TO ACTIVATE JAILS:
+#
+# YOU SHOULD NOT MODIFY THIS FILE.
+#
+# It will probably be overwritten or improved in a distribution update.
+#
+# Provide customizations in a jail.local file or a jail.d/customisation.local.
+# For example to change the default bantime for all jails and to enable the
+# ssh-iptables jail the following (uncommented) would appear in the .local file.
+# See man 5 jail.conf for details.
+#
+# [DEFAULT]
+# bantime = 3600
+#
+# [sshd]
+# enabled = true
+#
+# See jail.conf(5) man page for more information
+
+
+
+# Comments: use '#' for comment lines and ';' (following a space) for inline comments
+
+
+[INCLUDES]
+
+#before = paths-distro.conf
+before = paths-debian.conf
+
+# The DEFAULT allows a global definition of the options. They can be overridden
+# in each jail afterwards.
+
+[DEFAULT]
+
+#
+# MISCELLANEOUS OPTIONS
+#
+
+# "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
+# ban a host which matches an address in this list. Several addresses can be
+# defined using space separator.
+ignoreip = "{{ F2B_IGNOREIP | join(' ') }}"
+
+# External command that will take an tagged arguments to ignore, e.g. <ip>,
+# and return true if the IP is to be ignored. False otherwise.
+#
+# ignorecommand = /path/to/command <ip>
+ignorecommand =
+
+# "bantime" is the number of seconds that a host is banned.
+bantime  = {{ BANTIME }}
+
+# A host is banned if it has generated "maxretry" during the last "findtime"
+# seconds.
+findtime  = 600
+
+# "maxretry" is the number of failures before a host get banned.
+maxretry = {{ MAX_RETRY }}
+
+# "backend" specifies the backend used to get files modification.
+# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
+# This option can be overridden in each jail as well.
+#
+# pyinotify: requires pyinotify (a file alteration monitor) to be installed.
+#              If pyinotify is not installed, Fail2ban will use auto.
+# gamin:     requires Gamin (a file alteration monitor) to be installed.
+#              If Gamin is not installed, Fail2ban will use auto.
+# polling:   uses a polling algorithm which does not require external libraries.
+# systemd:   uses systemd python library to access the systemd journal.
+#              Specifying "logpath" is not valid for this backend.
+#              See "journalmatch" in the jails associated filter config
+# auto:      will try to use the following backends, in order:
+#              pyinotify, gamin, polling.
+#
+# Note: if systemd backend is choses as the default but you enable a jail
+#       for which logs are present only in its own log files, specify some other
+#       backend for that jail (e.g. polling) and provide empty value for
+#       journalmatch. See https://github.com/fail2ban/fail2ban/issues/959#issuecomment-74901200
+backend = auto
+
+# "usedns" specifies if jails should trust hostnames in logs,
+#   warn when DNS lookups are performed, or ignore all hostnames in logs
+#
+# yes:   if a hostname is encountered, a DNS lookup will be performed.
+# warn:  if a hostname is encountered, a DNS lookup will be performed,
+#        but it will be logged as a warning.
+# no:    if a hostname is encountered, will not be used for banning,
+#        but it will be logged as info.
+usedns = warn
+
+# "logencoding" specifies the encoding of the log files handled by the jail
+#   This is used to decode the lines from the log file.
+#   Typical examples:  "ascii", "utf-8"
+#
+#   auto:   will use the system locale setting
+logencoding = auto
+
+# "enabled" enables the jails.
+#  By default all jails are disabled, and it should stay this way.
+#  Enable only relevant to your setup jails in your .local or jail.d/*.conf
+#
+# true:  jail will be enabled and log files will get monitored for changes
+# false: jail is not enabled
+enabled = false
+
+
+# "filter" defines the filter to use by the jail.
+#  By default jails have names matching their filter name
+#
+filter = %(__name__)s
+
+
+#
+# ACTIONS
+#
+
+# Some options used for actions
+
+# Destination email address used solely for the interpolations in
+# jail.{conf,local,d/*} configuration files.
+destemail = {{ DESTEMAIL }}
+
+# Sender email address used solely for some actions
+sender = {{ SENDERNAME }}
+
+# E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
+# mailing. Change mta configuration parameter to mail if you want to
+# revert to conventional 'mail'.
+mta = sendmail
+
+# Default protocol
+protocol = tcp
+
+# Specify chain where jumps would need to be added in iptables-* actions
+chain = INPUT
+
+# Ports to be banned
+# Usually should be overridden in a particular jail
+port = 0:65535
+
+#
+# Action shortcuts. To be used to define action parameter
+
+# Default banning action (e.g. iptables, iptables-new,
+# iptables-multiport, shorewall, etc) It is used to define
+# action_* variables. Can be overridden globally or per
+# section within jail.local file
+banaction = iptables-multiport
+
+# The simplest action to take: ban only
+action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report to the destemail.
+action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+            %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
+#
+# ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
+# to the destemail.
+action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+
+# ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
+                %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# Report block via blocklist.de fail2ban reporting service API
+# 
+# See the IMPORTANT note in action.d/blocklist_de.conf for when to
+# use this action. Create a file jail.d/blocklist_de.local containing
+# [Init]
+# blocklist_de_apikey = {api key from registration]
+#
+action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s"]
+
+# Report ban via badips.com, and use as blacklist
+#
+# See BadIPsAction docstring in config/action.d/badips.py for
+# documentation for this action.
+#
+# NOTE: This action relies on banaction being present on start and therefore
+# should be last action defined for a jail.
+#
+action_badips = badips.py[category="%(name)s", banaction="%(banaction)s"]
+
+# Choose default action.  To change, just override value of 'action' with the
+# interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
+# globally (section [DEFAULT]) or per specific section
+action = %({{ F2B_ACTION }})s
+
+
+#
+# JAILS
+#
+
+#
+# SSH servers
+#
+
+[sshd]
+
+enabled  = true
+port    = {{ SSH_PORT }}
+logpath = %(sshd_log)s
+maxretry = {{ MAX_RETRY }}
+
+[sshd-ddos]
+# This jail corresponds to the standard configuration in Fail2ban.
+# The mail-whois action send a notification e-mail with a whois request
+# in the body.
+enabled  = false
+port     = {{ SSH_PORT }}
+logpath = %(sshd_log)s
+maxretry = 6
+
+[dropbear]
+
+port     = ssh
+logpath  = %(dropbear_log)s
+
+
+[selinux-ssh]
+
+port     = ssh
+logpath  = %(auditd_log)s
+maxretry = 5
+
+
+#
+# HTTP servers
+#
+
+[apache-auth]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+
+
+[apache-badbots]
+# Ban hosts which agent identifies spammer robots crawling the web
+# for email addresses. The mail outputs are buffered.
+port     = http,https
+logpath  = %(apache_access_log)s
+bantime  = 172800
+maxretry = 1
+
+
+[apache-noscript]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 6
+
+
+[apache-overflows]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-nohome]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-botsearch]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-fakegooglebot]
+
+port     = http,https
+logpath  = %(apache_access_log)s
+maxretry = 1
+ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
+
+
+[apache-modsecurity]
+
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+[apache-shellshock]
+
+port    = http,https
+logpath = %(apache_error_log)s
+maxretry = 1
+
+[nginx-http-auth]
+
+port    = http,https
+logpath = %(nginx_error_log)s
+
+[nginx-botsearch]
+
+port     = http,https
+logpath  = %(nginx_error_log)s
+maxretry = 2
+
+# Ban attackers that try to use PHP's URL-fopen() functionality
+# through GET/POST variables. - Experimental, with more than a year
+# of usage in production environments.
+
+[php-url-fopen]
+
+port    = http,https
+logpath = %(nginx_access_log)s
+          %(apache_access_log)s
+
+
+[suhosin]
+
+port    = http,https
+logpath = %(suhosin_log)s
+
+
+[lighttpd-auth]
+# Same as above for Apache's mod_auth
+# It catches wrong authentifications
+port    = http,https
+logpath = %(lighttpd_error_log)s
+
+
+#
+# Webmail and groupware servers
+#
+
+[roundcube-auth]
+
+port     = http,https
+logpath  = logpath = %(roundcube_errors_log)s
+
+
+[openwebmail]
+
+port     = http,https
+logpath  = /var/log/openwebmail.log
+
+
+[horde]
+
+port     = http,https
+logpath  = /var/log/horde/horde.log
+
+
+[groupoffice]
+
+port     = http,https
+logpath  = /home/groupoffice/log/info.log
+
+
+[sogo-auth]
+# Monitor SOGo groupware server
+# without proxy this would be:
+# port    = 20000
+port     = http,https
+logpath  = /var/log/sogo/sogo.log
+
+
+[tine20]
+
+logpath  = /var/log/tine20/tine20.log
+port     = http,https
+maxretry = 5
+
+
+#
+# Web Applications
+#
+#
+
+[drupal-auth]
+
+port     = http,https
+logpath  = %(syslog_daemon)s
+
+[guacamole]
+
+port     = http,https
+logpath  = /var/log/tomcat*/catalina.out
+
+[monit]
+#Ban clients brute-forcing the monit gui login
+filter   = monit
+port = 2812
+logpath  = /var/log/monit
+
+
+[webmin-auth]
+
+port    = 10000
+logpath = %(syslog_authpriv)s
+
+
+[froxlor-auth]
+
+port    = http,https
+logpath  = %(syslog_authpriv)s
+
+
+#
+# HTTP Proxy servers
+#
+#
+
+[squid]
+
+port     =  80,443,3128,8080
+logpath = /var/log/squid/access.log
+
+
+[3proxy]
+
+port    = 3128
+logpath = /var/log/3proxy.log
+
+
+#
+# FTP servers
+#
+
+
+[proftpd]
+
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(proftpd_log)s
+
+
+[pure-ftpd]
+
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(pureftpd_log)s
+maxretry = 6
+
+
+[gssftpd]
+
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(syslog_daemon)s
+maxretry = 6
+
+
+[wuftpd]
+
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(wuftpd_log)s
+maxretry = 6
+
+
+[vsftpd]
+# or overwrite it in jails.local to be
+# logpath = %(syslog_authpriv)s
+# if you want to rely on PAM failed login attempts
+# vsftpd's failregex should match both of those formats
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(vsftpd_log)s
+
+
+#
+# Mail servers
+#
+
+# ASSP SMTP Proxy Jail
+[assp]
+
+port     = smtp,465,submission
+logpath  = /root/path/to/assp/logs/maillog.txt
+
+
+[courier-smtp]
+
+port     = smtp,465,submission
+logpath  = %(syslog_mail)s
+
+
+[postfix]
+
+port     = smtp,465,submission
+logpath  = %(postfix_log)s
+
+
+[postfix-rbl]
+
+port     = smtp,465,submission
+logpath  = %(syslog_mail)s
+maxretry = 1
+
+
+[sendmail-auth]
+
+port    = submission,465,smtp
+logpath = %(syslog_mail)s
+
+
+[sendmail-reject]
+
+port     = smtp,465,submission
+logpath  = %(syslog_mail)s
+
+
+[qmail-rbl]
+
+filter  = qmail
+port    = smtp,465,submission
+logpath = /service/qmail/log/main/current
+
+
+# dovecot defaults to logging to the mail syslog facility
+# but can be set by syslog_facility in the dovecot configuration.
+[dovecot]
+
+port    = pop3,pop3s,imap,imaps,submission,465,sieve
+logpath = %(dovecot_log)s
+
+
+[sieve]
+
+port   = smtp,465,submission
+logpath = %(dovecot_log)s
+
+
+[solid-pop3d]
+
+port    = pop3,pop3s
+logpath = %(solidpop3d_log)s
+
+
+[exim]
+
+port   = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[exim-spam]
+
+port   = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[kerio]
+
+port    = imap,smtp,imaps,465
+logpath = /opt/kerio/mailserver/store/logs/security.log
+
+
+#
+# Mail servers authenticators: might be used for smtp,ftp,imap servers, so
+# all relevant ports get banned
+#
+
+[courier-auth]
+
+port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+logpath  = %(syslog_mail)s
+
+
+[postfix-sasl]
+
+port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+# You might consider monitoring /var/log/mail.warn instead if you are
+# running postfix since it would provide the same log lines at the
+# "warn" level but overall at the smaller filesize.
+logpath  = %(postfix_log)s
+
+
+[perdition]
+
+port   = imap3,imaps,pop3,pop3s
+logpath = %(syslog_mail)s
+
+
+[squirrelmail]
+
+port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
+
+
+[cyrus-imap]
+
+port   = imap3,imaps
+logpath = %(syslog_mail)s
+
+
+[uwimap-auth]
+
+port   = imap3,imaps
+logpath = %(syslog_mail)s
+
+
+#
+#
+# DNS servers
+#
+
+
+# !!! WARNING !!!
+#   Since UDP is connection-less protocol, spoofing of IP and imitation
+#   of illegal actions is way too simple.  Thus enabling of this filter
+#   might provide an easy way for implementing a DoS against a chosen
+#   victim. See
+#    http://nion.modprobe.de/blog/archives/690-fail2ban-+-dns-fail.html
+#   Please DO NOT USE this jail unless you know what you are doing.
+#
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks UDP traffic for DNS requests.
+# [named-refused-udp]
+#
+# filter   = named-refused
+# port     = domain,953
+# protocol = udp
+# logpath  = /var/log/named/security.log
+
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks TCP traffic for DNS requests.
+
+[named-refused]
+
+port     = domain,953
+logpath  = /var/log/named/security.log
+
+
+[nsd]
+
+port     = 53
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+logpath = /var/log/nsd.log
+
+
+#
+# Miscellaneous
+#
+
+[asterisk]
+
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+logpath  = /var/log/asterisk/messages
+maxretry = 10
+
+
+[freeswitch]
+
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+logpath  = /var/log/freeswitch.log
+maxretry = 10
+
+
+# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
+# equivalent section:
+# log-warning = 2
+#
+# for syslog (daemon facility)
+# [mysqld_safe]
+# syslog
+#
+# for own logfile
+# [mysqld]
+# log-error=/var/log/mysqld.log
+[mysqld-auth]
+
+port     = 3306
+logpath  = %(mysql_log)s
+maxretry = 5
+
+
+# Jail for more extended banning of persistent abusers
+# !!! WARNINGS !!!
+# 1. Make sure that your loglevel specified in fail2ban.conf/.local
+#    is not at DEBUG level -- which might then cause fail2ban to fall into
+#    an infinite loop constantly feeding itself with non-informative lines
+# 2. Increase dbpurgeage defined in fail2ban.conf to e.g. 648000 (7.5 days)
+#    to maintain entries for failed logins for sufficient amount of time
+[recidive]
+
+logpath  = /var/log/fail2ban.log
+banaction = iptables-allports
+bantime  = 604800  ; 1 week
+findtime = 86400   ; 1 day
+maxretry = 5
+
+
+# Generic filter for PAM. Has to be used with action which bans all
+# ports such as iptables-allports, shorewall
+
+[pam-generic]
+# pam-generic filter can be customized to monitor specific subset of 'tty's
+banaction = iptables-allports
+logpath  = %(syslog_authpriv)s
+
+
+[xinetd-fail]
+
+banaction = iptables-multiport-log
+logpath   = %(syslog_daemon)s
+maxretry  = 2
+
+
+# stunnel - need to set port for this
+[stunnel]
+
+logpath = /var/log/stunnel4/stunnel.log
+
+
+[ejabberd-auth]
+
+port    = 5222
+logpath = /var/log/ejabberd/ejabberd.log
+
+
+[counter-strike]
+
+logpath = /opt/cstrike/logs/L[0-9]*.log
+# Firewall: http://www.cstrike-planet.com/faq/6
+tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
+action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+
+# consider low maxretry and a long bantime
+# nobody except your own Nagios server should ever probe nrpe
+[nagios]
+
+enabled  = false
+logpath  = %(syslog_daemon)s     ; nrpe.cfg may define a different log_facility
+maxretry = 1
+
+
+[oracleims]
+# see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
+enabled = false
+logpath = /opt/sun/comms/messaging64/log/mail.log_current
+maxretry = 6
+banaction = iptables-allports
+
+[directadmin]
+enabled = false
+logpath = /var/log/directadmin/login.log
+port = 2222
+
+[portsentry]
+enabled  = false
+logpath  = /var/lib/portsentry/portsentry.history
+maxretry = 1
+
+[pass2allow-ftp]
+# this pass2allow example allows FTP traffic after successful HTTP authentication
+port         = ftp,ftp-data,ftps,ftps-data
+# knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
+filter       = apache-pass
+# access log of the website with HTTP auth
+logpath      = %(apache_access_log)s
+blocktype    = RETURN
+returntype   = DROP
+bantime      = 3600
+maxretry     = 1
+findtime     = 1

--- a/ansible/roles/atmo-local-user-account/tasks/main.yml
+++ b/ansible/roles/atmo-local-user-account/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for atmo-local-user-account
+
+- name: create local user account
+  user: name="{{ ATMOUSERNAME }}" state=present shell=/bin/bash 
+  tags: account
+
+
+- name: create home directory for user if not already created
+  file: path=/home/{{ ATMOUSERNAME }} state=directory mode=0700
+  tags: home-dir

--- a/ansible/roles/atmo-realvncserver/files/config.custom
+++ b/ansible/roles/atmo-realvncserver/files/config.custom
@@ -1,6 +1,6 @@
 # vncserver common.custom configuration.
 SecurityTypes=RA2
-Permissions=root:f,%core-services:f,:f
+Permissions=root:f,:f
 EnableAutoUpdateChecks=1
 
 # Atmosphere port configuration.

--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -73,6 +73,15 @@
 
 - name: kill all running vncserver sessions
   shell: /bin/su {{ ATMOUSERNAME }} -c "/usr/bin/vncserver -kill :'{{ item }}'"
+  with_items:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
   failed_when: False
   tags: kill-vnc
 

--- a/ansible/roles/atmo-realvncserver/tasks/main.yml
+++ b/ansible/roles/atmo-realvncserver/tasks/main.yml
@@ -73,15 +73,6 @@
 
 - name: kill all running vncserver sessions
   shell: /bin/su {{ ATMOUSERNAME }} -c "/usr/bin/vncserver -kill :'{{ item }}'"
-  with_items:
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-    - 6
-    - 7
-    - 8
   failed_when: False
   tags: kill-vnc
 
@@ -93,7 +84,6 @@
   when: xsession.stat.exists and xterm.stat.exists
   failed_when: False
   tags: vnc
-
 
 - name: set environment variables for legacy systems
   set_fact: ansible_python_interpreter=/usr/bin/python26

--- a/ansible/roles/atmo-realvncserver/vars/CentOS.yml
+++ b/ansible/roles/atmo-realvncserver/vars/CentOS.yml
@@ -20,5 +20,6 @@ XGUI:
     - { PATH: /tmp/.X1-lock, STATE: absent }
     - { PATH: /tmp/.X11-unix, STATE: absent }
     - { PATH: /tmp/VNC-Server-5.2.3-Linux-x64.rpm, STATE: absent }
+
   dirs_to_make:
     - { PATH: /tmp/.X11-unix, STATE: directory, MODE: "a+rwxt" }

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -7,11 +7,10 @@
   lineinfile:
     dest=/etc/sudoers
     backup=yes
-    line="{{ item }}" 
+    line="{{ item }}"
   with_items: 
-    - '%core-services ALL=(ALL) ALL'  
-    - '%users ALL=(ALL) ALL'
-    - '{{ ATMOUSERNAME }} ALL=(ALL)ALL'
+    - '%users ALL=(ALL) NOPASSWD: ALL'
+    - '{{ ATMOUSERNAME }} ALL=(ALL) NOPASSWD:ALL'
 
 - name: start setting up /etc/skel/.bashrc
   lineinfile: dest=/etc/skel/.bashrc line='## Atmosphere System'

--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -26,13 +26,15 @@
 
   # tasks file for exit-code
 - name: see if user is already located in /etc/group
-  command: grep {{ ATMOUSERNAME }} /etc/group
+  command: grep "users:x:100:.*{{ ATMOUSERNAME }}.*" /etc/group
   register: user_not_present
   failed_when: False
+  tags: debug-ssh
 
 - name: add user to /etc/group if user does not exist
   lineinfile: dest=/etc/group regexp='^(users:x:100:)(.*)' line="\1{{ ATMOUSERNAME }},\2" state=present backrefs=yes
   when: user_not_present.rc == 1
+  tags: debug-ssh
 
 # add user to docker group
 - name: see if user is already located in /etc/group

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -78,8 +78,8 @@
     - debug
     - delete
 
-- name: Append AllowUsers Line to /etc/ssh/sshd_config 
-  lineinfile: dest=/etc/ssh/sshd_config line="AllowUsers root {{ ATMOUSERNAME }}"
+- name: Append AllowGroups Line to /etc/ssh/sshd_config 
+  lineinfile: dest=/etc/ssh/sshd_config line="AllowGroups root users"
   tags:
     - debug
 

--- a/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
+++ b/ansible/roles/atmo-user-ssh-keys/tasks/main.yml
@@ -19,6 +19,7 @@
     user="{{ item }}"
   when: pk_file is defined
   with_items:
+    - root
     - "{{ ATMOUSERNAME }}"
   tags:
     - ssh-keys

--- a/ansible/roles/gateone-gen-sshkey/tasks/main.yml
+++ b/ansible/roles/gateone-gen-sshkey/tasks/main.yml
@@ -9,26 +9,26 @@
 
 - name: ensure the existence of the user directory
   file: path="/var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh" owner=root group=root mode=0700 state=directory
-  delegate_to: gateone
+  delegate_to: shell
 
 - name: check the existence of a given ssh key by name
   stat: path="/var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh/{{ ATMOUSERNAME }}_default"
   register: go_key
-  delegate_to: gateone
+  delegate_to: shell
 
 - name: generate the public key
   command: "/usr/bin/ssh-keygen -N '' -t rsa -b 2048 -f /var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh/{{ ATMOUSERNAME }}_default -C {{ ATMOUSERNAME }}"
   when: go_key.stat.exists == False
-  delegate_to: gateone
+  delegate_to: shell
 
 - name: set the permissions on the private key file
   file: path="/var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh/{{ ATMOUSERNAME }}_default" mode=0600
-  delegate_to: gateone
+  delegate_to: shell
 
 - name: add the key name to .default_ids
   lineinfile: dest="/var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh/.default_ids" line="{{ ATMOUSERNAME }}_default" create=yes state=present
-  delegate_to: gateone
+  delegate_to: shell
 
 - name: finally, transfer the public key locally
   fetch: src="/var/lib/gateone/users/{{ ATMOUSERNAME }}/.ssh/{{ ATMOUSERNAME }}_default.pub" dest="{{ GATEONE_LOCAL_PUBKEY_DIR | default('/tmp/') }}" flat=yes
-  delegate_to: gateone
+  delegate_to: shell


### PR DESCRIPTION
Added better matching for `grep` on `/etc/groups`.  Use `sshd_config` directive for AllowGroups so that adding a user account only consists of a `useradd`, adding that user to the `users` group and setting the password for that local account.