### PR TITLE
Switch to AllowGroups instead of AllowUsers

### DIFF
--- a/ansible/roles/atmo-setup-user/tasks/main.yml
+++ b/ansible/roles/atmo-setup-user/tasks/main.yml
@@ -29,13 +29,15 @@
 
   # tasks file for exit-code
 - name: see if user is already located in /etc/group
-  command: grep {{ ATMOUSERNAME }} /etc/group
+  command: grep "users:x:100:.*{{ ATMOUSERNAME }}.*" /etc/group
   register: user_not_present
   failed_when: False
+  tags: debug-ssh
 
 - name: add user to /etc/group if user does not exist
   lineinfile: dest=/etc/group regexp='^(users:x:100:)(.*)' line="\1{{ ATMOUSERNAME }},\2" state=present backrefs=yes
   when: user_not_present.rc == 1
+  tags: debug-ssh
 
 # add user to docker group
 - name: see if user is already located in /etc/group

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -79,7 +79,7 @@
     - delete
 
 - name: Append AllowGroups Line to /etc/ssh/sshd_config 
-  lineinfile: dest=/etc/ssh/sshd_config line="AllowGroups root users"
+  lineinfile: dest=/etc/ssh/sshd_config line="AllowGroups root core-services users"
   tags:
     - debug
 

--- a/ansible/roles/atmo-ssh-setup/tasks/main.yml
+++ b/ansible/roles/atmo-ssh-setup/tasks/main.yml
@@ -78,8 +78,8 @@
     - debug
     - delete
 
-- name: Append AllowUsers Line to /etc/ssh/sshd_config 
-  lineinfile: dest=/etc/ssh/sshd_config line="AllowUsers root {{ ATMOUSERNAME }}"
+- name: Append AllowGroups Line to /etc/ssh/sshd_config 
+  lineinfile: dest=/etc/ssh/sshd_config line="AllowGroups root users"
   tags:
     - debug
 


### PR DESCRIPTION
Added better matching for `grep` on `/etc/groups`.  Use `sshd_config` directive for AllowGroups so that adding a user account only consists of a `useradd`, adding that user to the `users` group and setting the password for that local account.

	modified:   roles/atmo-setup-user/tasks/main.yml
	modified:   roles/atmo-ssh-setup/tasks/main.yml

(cherry picked from commit 4a58145b0fada00fc8ed54e40d0a2ae1c1be9b7f)
(cherry picked from commit 9a3aeab03583d3239a5a55e2a88ec2571b670159)