### PR TITLE
Add atmo-common vars for Ubuntu 16

### DIFF
--- a/ansible/roles/atmo-common/vars/Ubuntu-16.yml
+++ b/ansible/roles/atmo-common/vars/Ubuntu-16.yml
@@ -1,0 +1,27 @@
+---
+
+SSHD: ssh
+
+RC_LOCAL_ATMO: /etc/rc.local.atmo
+
+PACKAGES:
+  - libfam0
+  - python
+  - python-ldap
+  - python-software-properties
+  - python-httplib2
+  - libfuse2
+  - tmux
+  - screen
+  - autoconf
+  - gcc
+  - make
+  - patch
+  - tcsh
+  - zsh
+  - mosh
+  - qemu-guest-agent
+
+# Add modules to be loaded here
+# MODULES_TO_LOAD:
+#   - acpiphp


### PR DESCRIPTION
	new file:   roles/atmo-common/vars/Ubuntu-16.yml

(cherry picked from commit 81967e0f75252a5f389c6d161a8d1e553c7c79cf)