### PR TITLE
Add extra permissions and logic to handle bare vms

### DIFF
--- a/ansible/roles/atmo-novnc/defaults/main.yml
+++ b/ansible/roles/atmo-novnc/defaults/main.yml
@@ -3,8 +3,7 @@
 
 REQUIRED:
   files_to_add:
-    - { FROM: passwd, TO: "/home/{{ ATMOUSERNAME }}/.vnc/passwd" }
-    #- { FROM: , TO:  }
+    - { PATH: "/home/{{ ATMOUSERNAME }}/.vnc/passwd", STATE: touch, MODE: "700", OWNER: "{{ ATMOUSERNAME }}", GROUP: "{{ ATMOUSERNAME }}" }
   files_to_remove:
     - { PATH: /tmp/.X1-lock, STATE: absent }
     - { PATH: /tmp/.X11-unix, STATE: absent }
@@ -17,12 +16,14 @@ REQUIRED:
     - { PATH: /etc/vnc/config.d/common.custom, STATE: absent }
     - { PATH: /etc/vnc/config.custom, STATE: absent }
   dirs_to_make:
-    - { PATH: /tmp/.X11-unix, STATE: directory, MODE: "a+rwxt" }
-    - { PATH: "/home/{{ ATMOUSERNAME }}", STATE: directory, MODE: "0750" }
+    - { PATH: /tmp/.X11-unix, STATE: directory, MODE: "a+rwxt", OWNER: "root", GROUP: "root" }
+    - { PATH: "/home/{{ ATMOUSERNAME }}", STATE: directory, MODE: "0750", OWNER: "{{ ATMOUSERNAME }}", GROUP: "{{ ATMOUSERNAME }}" }
+    - { PATH: "/home/{{ ATMOUSERNAME }}/.vnc", STATE: directory, MODE: "0750", OWNER: "{{ ATMOUSERNAME }}", GROUP: "{{ ATMOUSERNAME }}" }
 
 VNC_COMMANDS:
   - /bin/su {{ ATMOUSERNAME }} -c "/usr/bin/printf '%s\n%s\n' 'display' 'display' | vncpasswd /home/{{ ATMOUSERNAME }}/.vnc/passwd"
   - "/usr/bin/pkill websockify"
   - "for i in $(/usr/bin/pgrep -f '/opt/kanaka-noVNC-8b0a0f6/utils/');do /bin/echo 'killing process:' $i; /bin/kill -HUP $i;done"
   - "/bin/su {{ ATMOUSERNAME }} -c '/usr/bin/vncserver -localhost :1'"
+  # To disable NoVNC web when entering prod, remove "--web /usr/share/novnc/" from the command below
   - "websockify -D --web /usr/share/novnc/ 4200 localhost:5901"

--- a/ansible/roles/atmo-novnc/tasks/main.yml
+++ b/ansible/roles/atmo-novnc/tasks/main.yml
@@ -142,8 +142,14 @@
   tags: vnc
 
 - name: create needed directories
-  file: path={{ item.PATH }} state={{ item.STATE }} mode={{ item.MODE }}
+  file: path={{ item.PATH }} state={{ item.STATE }} mode={{ item.MODE }} owner={{ item.OWNER }} group={{ item.GROUP }}
   with_items: "{{ REQUIRED.dirs_to_make }}"
+  when: has_gui
+  tags: vnc
+
+- name: create needed files
+  file: path={{ item.PATH }} state={{ item.STATE }} mode={{ item.MODE }} owner={{ item.OWNER }} group={{ item.GROUP }}
+  with_items: "{{ REQUIRED.files_to_add }}"
   when: has_gui
   tags: vnc
 
@@ -168,10 +174,14 @@
   with_items:
     - /etc/X11/xinit/xinitrc
 
+- name: create user .vnc directory in home
+  file: path=/home/{{ ATMOUSERNAME }}/.vnc state=directory
+  tags: vnc
+
 - name: template xstartup for vncserver
-  template: src=xstartup.j2 dest="/home/{{ ATMOUSERNAME }}/.vnc/xstartup" mode=0755
+  template: src=xstartup.j2 dest="/home/{{ ATMOUSERNAME }}/.vnc/xstartup" mode=0755 owner={{ ATMOUSERNAME }} group={{ ATMOUSERNAME }}
   when: has_gui
-  tags: kill-vnc
+  tags: vnc
 
 - name: start vncserver and novnc
   shell: "{{ item }}"


### PR DESCRIPTION
Now fully supports bare boxes, in addition to being fully tested on CentOS 7.

	modified:   roles/atmo-novnc/defaults/main.yml
	modified:   roles/atmo-novnc/tasks/main.yml

(cherry picked from commit bbf5d88e1922501e5b1f376c3e8217830e26bb40)